### PR TITLE
Universalise backends

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -1,0 +1,79 @@
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code&display=swap');
+@import url('https://rsms.me/inter/inter.css');
+
+
+html {
+    background-color: #101010;
+    color: antiquewhite;
+    font-family: 'Inter', sans-serif;
+    height: 100%;
+}
+
+h1 {
+    text-align: center;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    margin: 10px;
+    height: calc(100% - 20px);
+}
+
+#container {
+    display: flex;
+    flex-direction: row;
+    flex: 0;
+    height: 90%;
+}
+
+#source {
+    flex: 1;
+    font-family: 'Fira Code', monospace;
+    font-size: 13px;
+    background-color: #333;
+    border-width: 0px;
+    border-radius: 5px;
+    padding: 15px;
+    color: antiquewhite;
+    margin-bottom: 30px;
+    resize: none;
+    margin-left: 100px;
+    height: 400px;
+}
+
+#run {
+    align-self: center;
+    width: 100px;
+    height: 50px;
+    border-width: 0px;
+    border-radius: 5px;
+    background-color: #222;
+    color: antiquewhite;
+    font-family: 'Inter', sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    transition: background-color 0.1s linear;
+
+}
+
+#run:hover {
+    background-color: #555;
+}
+
+#output {
+    flex: 1;
+    margin-left: 15px;
+    margin-right: 100px;
+    text-align: start;
+    border-width: 0px;
+    border-radius: 5px;
+    padding: 15px;
+    background-color: #333;
+    font-family: 'Fira Code', monospace;
+    font-weight: bold;
+    font-size: 13px;
+    height: 400px;
+    resize: none;
+    color: antiquewhite;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link href="./index.css" rel="stylesheet" type="text/css" />
+		<title>Pancake Online</title>
+	</head>
+	<body>
+		<h1>Pancake online</h1>
+
+		<div id="container">
+            <textarea
+                id="source"
+                tabindex="-1"
+                title="Pancake code"
+                placeholder='Write some Pancake code here and click "Run", output will appear on the right'
+            ></textarea>
+
+			<textarea
+				placeholder="If any, output and errors will appear here"
+				id="output"
+				disabled
+			></textarea>
+		</div>
+
+        <button id="run">Run</button>
+
+		<script src="../build/pancake.js"></script>
+	</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -40,11 +40,11 @@ Because
 **Prerequisites:**
 * the Nim toolchain (Nim compiler >= 1.4.0, Nimble).
 
-To install Pancake, clone this repository and run
+To install Pancake, and run
 ```
-nimble install
+nimble install https://github.com/c1m5j/pancake
 ```
-This will install the release Pancake interpreter. Now you can interpret Pancake source files using
+This will install the release-version Pancake interpreter. Now you can interpret Pancake source files using
 ```
 pancake FILENAME
 ```
@@ -154,6 +154,8 @@ All variables are mutable. In order to change the value of a variable, simply as
 Variables are """"""function-scoped"""""". Variables are unique to their procedure and a variable called `name` in `global` is different than a variable called `name` in a private or public procedure.
 
 ## Surprises!
+*(This treats about Pancake v0.1.1)*
+
 After I cleaned up this code for the first time and built a release binary, I decided to benchmark Pancake against Python 3.7.6, just for fun. The benchmarks I ran were
 
 * naïve calculation of 20!,
@@ -180,8 +182,14 @@ Something which is interesting, to me at least, is the contrast between the two 
 I put the code I used for both of the benchmarks in the "benchmarks" directory. There are also some other Pancake examples in the "examples" directory. If you have ideas for some other ways to represent how Pancake works with code snippets, feel free to contribute some examples.
 
 ## Future
-Features expected in the future are
+<!-- Features expected in the future are
 * data structures — I can't really tell if arrays have a place in this language, but at the same time it's odd to not have them,
 * a way to import Pancake files into other Pancake files in order to use its procedures. That brings us to
 * a standard library with common stuff that Pancake doesn't have and that could be defined using Pancake itself. Other than that, if we want stuff that can't be defined using Pancake, we also want
-* foreign function interfacing with Nim — just a way to write Pancake procedures in Nim and be able to call them in Pancake code.
+* foreign function interfacing with Nim — just a way to write Pancake procedures in Nim and be able to call them in Pancake code. -->
+What I'm planning to work on is
+* tail-recursive procedure optimisation for public procedures (because we can),
+* allowing the runtime to generate a binary file with the all the info another runtime would need in order to run the program, basically allow redistribution of Pancake programs,
+* making the runtime a bit of its own thing (like a language backend), and then having a lexer as an additional helper to read and parse source code, so we can have languages that compile to Pancake — with that, we'd generate JS code by itself from Pancake instead of having to compile the Nim VM source code to JS,
+* implementing more complex data types in a no-nonsense way (thinking of arrays specifically),
+* creating a standard library with some sort of foreign function interfacing (to allow reading files, creating servers).

--- a/src/lexer.nim
+++ b/src/lexer.nim
@@ -1,16 +1,21 @@
-from options import Option, none, some, isSome
+when not defined(js):
+    from options import Option, none, some, isSome
+    import error
 import token except TOKEN_AS_WORD
-import error
 import strformat, strutils
 
 type
     ## Packages data regarding the lexing process.
     Lexer* = ref object
+        when defined(js):
+            ok*:     bool                     ## whether the program is okay or if it has encountered an error
+            output*: string                   ## possible error of the program, `output` instead of `error` for consistency with the runtime
+        else:
+            error*: Option[PancakeError]     ## Potential lexing error
         source:         string               ## The given source string
         start, current: uint                 ## Lexer.source[Lexer.start]..<Lexer.source[Lexer.current] denotes the lexeme being currently processed
         line, column:   uint                 ## Indicates where in the input the lexer is working, saved to Token.line and Token.column for every token
         tokens*:        seq[Token]           ## The resulting tokens
-        error*:         Option[PancakeError] ## Potential lexing error
 
 #==================================#
 # TEMPLATES -----------------------#
@@ -28,53 +33,50 @@ template getCurrent(self: Lexer): char = self.source[self.current]
 ## Used when reporting errors.
 template sourcePosition(): untyped = &"{self.line}:{self.column}"
 
+## Makes checking for errors universal across backends.
+template hadError*(self: Lexer): bool =
+    when defined(js): not self.ok
+    else:             self.error.isSome()
+
 ## Constructs an error in the lexer with the given position and message.
-template constructError(m: untyped, p: untyped): untyped =
-    self.error = some(PancakeError(message: m, pos: p, kind: "lexing error"))
+template constructError(self: Lexer, m: string, p: string) =
+    when defined(js):
+        self.output = "(lexing error, " & p & ") " & m
+        self.ok = false
+    else:
+        self.error = some(PancakeError(message: m, pos: p, kind: "lexing error"))
 
 ## Fetches the string slice from Lexer.start to Lexer.current.
 template getSlice(self: Lexer): string = self.source[self.start..<self.current]
 
 #==================================#
-# PROC DEFINITIONS ----------------#
+# PROCS ---------------------------#
 #==================================#
 
 ## Prepares and returns a new Lexer instance.
-proc newLexer*(source: string): Lexer
-
-## Warps Lexer.start to Lexer.current and takes care of columns.
-proc warp(self: Lexer)
-
-## Goes through whitespace and stops at a non-whitespace character.
-proc skipWhitespace(self: Lexer)
-
-## "Chomps" on input and stops Lexer.current at a place such that
-## getSlice() forms a valid lexeme.
-proc chomp(self: Lexer)
-
-## Processes the input.
-proc run*(self: Lexer)
-
-
-#==================================#
-# PROC IMPLEMENTATIONS ------------#
-#==================================#
-
 proc newLexer*(source: string): Lexer =
-    Lexer(
+    result = Lexer(
         source: source.replace("\t", "    "),
         start: 0,
         current: 0,
         line: 1,
         column: 1,
         tokens: newSeq[Token](),
-        error: none[PancakeError]()
     )
+    when defined(js):
+        result.ok = true
+        result.output = ""
+    else:
+        result.error = none[PancakeError]()
 
+
+## "Warps" Lexer.start to Lexer.current and takes care of columns.
 proc warp(self: Lexer) =
     self.column += self.current - self.start
     self.start = self.current
 
+
+## Advances through whitespace and stops at a non-whitespace character.
 proc skipWhitespace(self: Lexer) =
     var comment = false
     while not self.isPastEnd():
@@ -91,6 +93,9 @@ proc skipWhitespace(self: Lexer) =
         inc self.current
     self.warp()
 
+
+## "Chomps" on input and stops Lexer.current at a place such that
+## getSlice() forms a valid lexeme.
 proc chomp(self: Lexer) =
     if self.getCurrent() in Digits or
     (self.getCurrent() == '-' and
@@ -102,7 +107,7 @@ proc chomp(self: Lexer) =
         var isFloat = false
         while not self.isPastEnd() and self.getCurrent() in Digits + {'.'}:
             if self.getCurrent() == '.' and isFloat:
-                constructError(&"Bad number signature", sourcePosition)
+                self.constructError(&"Bad number signature", sourcePosition)
                 break
             elif self.getCurrent() == '.' and not isFloat:
                 isFloat = true
@@ -112,7 +117,7 @@ proc chomp(self: Lexer) =
         inc self.current
         while self.getCurrent() != '"':
             if self.isPastEnd() or self.getCurrent() == '\n':
-                constructError(&"Unterminated string", sourcePosition)
+                self.constructError(&"Unterminated string", sourcePosition)
                 break
             inc self.current
     
@@ -121,23 +126,23 @@ proc chomp(self: Lexer) =
     elif self.getCurrent() == '$':
         inc self.current
         if self.getCurrent() notin Digits:
-            constructError("Expected natural number after argument call operator", sourcePosition)
+            self.constructError("Expected natural number after argument call operator", sourcePosition)
             return
         while not self.isPastEnd() and self.getCurrent() in Digits: inc self.current
     elif self.getCurrent() in IdentStartChars:
         while not self.isPastEnd() and self.getCurrent() in IdentStartChars: inc self.current # (we don't allow numbers in identifiers)
     else:
-        constructError(&"Unrecognized token", sourcePosition)
+        self.constructError(&"Unrecognized token", sourcePosition)
         return
 
 
-
+## Processes the input.
 proc run*(self: Lexer) =
     while not self.isPastEnd():
         self.skipWhitespace()
         if self.isPastEnd(): break
         self.chomp()
-        if self.error.isSome(): return
+        if self.hadError(): return
 
         let slice = self.getSlice()
 
@@ -190,7 +195,7 @@ proc run*(self: Lexer) =
                 tok.lexeme = tok.lexeme[1..^1]
                 tok.kind = TK_Argument
             else:
-                constructError(&"Unrecognized token", sourcePosition)
+                self.constructError(&"Unrecognized token", sourcePosition)
                 break
         self.tokens.add(tok)
         self.warp()

--- a/src/pancake.nim
+++ b/src/pancake.nim
@@ -1,11 +1,18 @@
-from options import isSome, get
-from terminal import styledWrite, styleDim, resetStyle
-import error
-import argparse
+when not defined(js):
+    from options import isSome, get
+    from terminal import styledWrite, styleDim, resetStyle
+    import argparse
+
+    import error
+
+when defined(js):
+    import sugar
+    import dom
+
 import lexer, runtime
 
-
-when isMainModule:
+## For C backend
+when isMainModule and not defined(js):
     let parser = newParser("pancake"):
         help("This is the CLI that lets you communicate with your Pancake interpreter.")
         arg("filename", help="Path to file for Pancake to interpret")
@@ -19,7 +26,7 @@ when isMainModule:
 #==================================#
         let lex = newLexer(source)
         lex.run()
-        if lex.error.isSome():
+        if lex.hadError():
             raise lex.error.get()
         
 #==================================#
@@ -27,7 +34,7 @@ when isMainModule:
 #==================================#
         let runt = newRuntime(lex.tokens)
         runt.run()
-        if runt.error.isSome():
+        if runt.hadError():
             raise runt.error.get()
 
 #==================================#
@@ -43,3 +50,35 @@ when isMainModule:
     except UsageError, ShortCircuit:
         echo parser.help()
         quit(1)
+
+## For JavaScript backend
+when isMainModule and defined(js):
+    ## Runs the program, taking its source code from the left-side #source div.
+    proc run(button: Element) =
+        let textarea = document.getElementById("source")
+        let source = textarea.value
+        let output = document.getElementById("output")
+
+        button.disabled = true
+        
+#==================================#
+# LEXING --------------------------#
+#==================================#
+        let l = newLexer($source)
+        l.run()
+        if l.hadError():
+            output.value = l.output
+            button.disabled = false
+            return
+
+#==================================#
+# RUNTIME -------------------------#
+#==================================#
+        let r = newRuntime(l.tokens)
+        r.run()
+
+        output.value = r.output
+        button.disabled = false
+
+    let button = document.getElementById("run")
+    button.addEventListener("mousedown", (ev: Event) => run(button))

--- a/src/token.nim
+++ b/src/token.nim
@@ -1,26 +1,70 @@
-from tables import toTable
-
 type
     ## Denotes the possible types of a token.
     TokenKind* = enum
-        TK_LeftBrace, TK_RightBrace,          ## { }
-        TK_Plus, TK_Minus, TK_Star, TK_Slash, ## + - * /
-        TK_Neg,                               ## neg
-        TK_Global, TK_Public, TK_Private,     ## global public private
-        TK_Equal,                             ## =
-        TK_EndIf, TK_BeginIf,                 ## . ?
-        TK_To,                                ## to
-        TK_Argument,                          ## $ followed by a non-negative integer
-        TK_Out, TK_In,                        ## out in
-        TK_Dup, TK_Pop, TK_Swap, TK_Rotate,   ## dup ~ sw rot
-        TK_Return,                            ## ret
-        TK_True, TK_False,                    ## true false
-        TK_And, TK_Or, TK_Not                 ## & | !
-        TK_Number,                            ## any integer or floating point number in base 10
-        TK_String,                            ## utf-8 characters excluding newline enclosed with "
-        TK_Identifier,                        ## any characters from {a..z} | {A..Z} | {_}
-        TK_EOF,                               ## end of file
-        TK_EOP                                ## end of procedure
+        ## { }
+        TK_LeftBrace = "left brace",
+        TK_RightBrace = "right brace",
+
+        ## + - * /
+        TK_Plus = "plus sign",
+        TK_Minus = "minus sign",
+        TK_Star = "star sign",
+        TK_Slash = "slash", 
+
+        ## neg
+        TK_Neg = "\"is negative\" operator",
+
+        ## global public private
+        TK_Global = "\"global\" keyword",
+        TK_Public = "\"public\" keyword",
+        TK_Private = "\"private\" keyword",
+
+        ## =
+        TK_Equal = "\"equal\" operator",
+
+        ## . ?
+        TK_EndIf = "\"end if\" operator",
+        TK_BeginIf = "\"begin if\" operator",
+
+        ## to
+        TK_To = "\"to\" operator",
+
+        ## $ followed by a non-negative integer
+        TK_Argument = "argument call operator",
+
+        ## out in
+        TK_Out = "\"out\" operator",
+        TK_In = "\"in\" operator",
+
+        ## dup ~ sw rot
+        TK_Dup = "\"dup\" operator",
+        TK_Pop = "\"pop\" operator",
+        TK_Swap = "\"swap\" operator",
+        TK_Rotate = "\"rotate\" operator",
+
+        ## ret
+        TK_Return = "\"return\" operator",
+
+        ## true false
+        TK_True = "\"true\" boolean literal",
+        TK_False = "\"false\" boolean literal",
+
+        ## & | !
+        TK_And = "\"and\" boolean operator",
+        TK_Or = "\"or\" boolean operator",
+        TK_Not = "\"not\" boolean operator",
+
+        ## any integer or floating point number in base 10
+        TK_Number = "number literal",
+
+        ## utf-8 characters excluding newline enclosed with "
+        TK_String = "string literal",
+
+        ## any characters from {a..z} | {A..Z} | {_}
+        TK_Identifier = "identifier",
+
+        TK_EOF = "end of file",                           
+        TK_EOP = "end of procedure"
 
     ## Packages data regarding a token. A seq[Token]
     ## is the result of the process of lexing and it does not
@@ -30,37 +74,3 @@ type
         kind*:          TokenKind
         lexeme*:        string    # The "value" of the token, what portion of the source string it corresponds to
         line*, column*: uint      # The position of the token in the file
-
-## Used in reporting errors during runtime.
-const TOKEN_AS_WORD* = {
-    TK_BeginIf: "\"begin if\" operator",
-    TK_Return: "\"return\" keyword",
-    TK_EndIf: "\"end if\" operator",
-    TK_To: "\"to\" keyword",
-    TK_LeftBrace: "left brace",
-    TK_RightBrace: "right brace",
-    TK_Plus: "plus sign",
-    TK_Minus: "minus sign",
-    TK_Star: "star sign",
-    TK_Slash: "slash",
-    TK_Neg: "\"is negative\" operator",
-    TK_Global: "\"global\" keyword",
-    TK_Public: "\"public\" keyword",
-    TK_Private: "\"private\" keyword",
-    TK_Out: "\"out\" keyword",
-    TK_In: "\"in\" keyword",
-    TK_Dup: "\"dup\" keyword",
-    TK_String: "string literal",
-    TK_Identifier: "identifier",
-    TK_Number: "number literal",
-    TK_True: "\"true\" value",
-    TK_False: "\"false\" value",
-    TK_Argument: "argument call operator",
-    TK_And: "\"and\" boolean operator",
-    TK_Or: "\"or\" boolean operator",
-    TK_Not: "\"not\" boolean operator",
-    TK_Equal: "\"equal\" operator",
-    TK_Pop: "\"pop\" operator",
-    TK_Swap: "\"swap\" operator",
-    TK_Rotate: "\"rotate\" operator",
-}.toTable()

--- a/src/value.nim
+++ b/src/value.nim
@@ -1,44 +1,37 @@
 type
     ## Denotes the possible kinds of a Pancake literal.
     ValueKind* = enum
-        VK_String,
-        VK_Number,
-        VK_Bool
+        VK_String = "string",
+        VK_Number = "number",
+        VK_Bool = "boolean"
 
+when not defined(js):
     ## A hack to make value-handling easier and leaner. Due
     ## to the fact that unions can only hold one value at a time,
     ## and a Pancake value can only be one type at a time as well,
     ## this is a good solution to representing values dynamically during
     ## runtime.
+    ## It's actually a union only on non-JS backends.
     ## Yes, stolen from Crafting Interpreters.
-    ValueUnion {.union.} = ref object
+    type ValueUnion {.union.} = ref object
+        str*:     string
+        num*:     float
+        boolean*: bool
+else:
+    type ValueUnion = ref object
         str*:     string
         num*:     float
         boolean*: bool
 
-    ## Represents a Pancake literal during runtime.
-    Value* = ref object
-        kind*:    ValueKind
-        valueAs*: ValueUnion
-
-
-#==================================#
-# PROC DEFINITIONS ----------------#
-#==================================#
-
-## All these return Value instances from given Nim types.
-proc newValue*(value: string): Value
-proc newValue*(value: float): Value
-proc newValue*(value: bool): Value
-
-## This overload is used when we want to copy a Value,
-## since we cannot do `val1 = val2`, as Value is a `ref object`
-## and that would just copy the address.
-proc newValue*(value: Value): Value
+## Represents a Pancake literal during runtime.
+type Value* = ref object
+    kind*:    ValueKind
+    valueAs*: ValueUnion
 
 #==================================#
-# PROC IMPLEMENTATIONS ------------#
+# PROCS ---------------------------#
 #==================================#
+# All these return Value instances from given Nim types.
 
 proc newValue*(value: string): Value =
     Value(
@@ -58,6 +51,9 @@ proc newValue*(value: bool): Value =
         valueAs: ValueUnion(boolean: value)
     )
 
+## This overload is used when we want to copy a Value,
+## since we cannot do `val1 = val2`, as Value is a `ref object`
+## and that would just copy the address.
 proc newValue*(value: Value): Value =
     Value(
         kind: value.kind,


### PR DESCRIPTION
We shouldn't need the `web` branch. Instead, we should be able to build the same codebase to whichever Nim backend we want. This takes care of that by using the appropriate `when defined(js)` guards.