### PR TITLE
Tail recursion optimisation

### DIFF
--- a/pancake.nimble
+++ b/pancake.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.4"
+version       = "0.1.5"
 author        = "c1m5j"
 description   = "stack-oriented pain-maximising toy programming language"
 license       = "MIT"


### PR DESCRIPTION
This implements tail recursion elimination optimisation; if we know that a public procedure call is the final action in a procedure, we can simply update `Runtime.environment` and jump back with `Runtime.environment.pc = 0` without having to recursively call `Runtime.runProcedure`.